### PR TITLE
Add Rmfrac 

### DIFF
--- a/FunctionalData.md
+++ b/FunctionalData.md
@@ -163,6 +163,7 @@ data methods:
 -   `r pkg("fdaACF")` contains functions to quantify the
     serial correlation across lags of a given functional time series, see also 
     [github.com/GMestreM/fdaACF](https://github.com/GMestreM/fdaACF) .
+-   `r pkg("Rmfrac")` package provides tools for simulation of fractional and          multifractional processes; estimation of the Hurst function, local fractal dimension,  and related geometric statistics; and Hurst function based clustering of time series. 
 
 ### Visualization and Exploratory Data Analysis
 


### PR DESCRIPTION
Hi @jdtuck 

This adds the package [Rmfrac]() to the 'Time series of functional data' section of the task view. 
I am the maintainer of this package. 

Use "Rmfrac package provides tools for simulation and analysis of fractional and multifractional processes" if more shorter description is needed. 

Feel free to edit or move to a more appropriate location.

Thanks.